### PR TITLE
fix(antsdre200): fix DMA synth by adding sync_event source

### DIFF
--- a/library/axi_dmac/axi_dmac_ip.tcl
+++ b/library/axi_dmac/axi_dmac_ip.tcl
@@ -7,6 +7,7 @@ adi_ip_create axi_dmac
 adi_ip_files axi_dmac [list \
   "$ad_hdl_dir/library/common/ad_mem_asym.v" \
   "$ad_hdl_dir/library/common/up_axi.v" \
+  "$ad_hdl_dir/library/util_cdc/sync_event.v" \
   "inc_id.vh" \
   "resp.vh" \
   "axi_dmac_burst_memory.v" \

--- a/projects/antsdre200/system_project.tcl
+++ b/projects/antsdre200/system_project.tcl
@@ -12,6 +12,7 @@ adi_project_files antsdre200 [list \
   "ltc2630_spi.v" \
   "system_constr.xdc" \
   "./ip/gen_clks/gen_clks.xci" \
+  "$ad_hdl_dir/library/util_cdc/sync_event.v" \
   "$ad_hdl_dir/library/common/ad_iobuf.v"]
 
 set_property is_enabled false [get_files  *system_sys_ps7_0.xdc]


### PR DESCRIPTION
axi_dmac RTL instantiates sync_event, but library/axi_dmac/axi_dmac_ip.tcl did not include "$ad_hdl_dir/library/util_cdc/sync_event.v", so Vivado couldn’t compile.

Build steps:
source /tools/Xilinx/Vivado/2019.1/settings64.sh
make -C library/axi_dmac clean
make -C library/axi_dmac xilinx
cd projects/antsdre200
make clean
make